### PR TITLE
fix: 为 PageController.Revert 添加认证和权限检查

### DIFF
--- a/src/ZKEACMS/Controllers/PageController.cs
+++ b/src/ZKEACMS/Controllers/PageController.cs
@@ -171,7 +171,7 @@ namespace ZKEACMS.Controllers
             return View("PreView");
         }
 
-        [HttpPost]
+        [HttpPost, DefaultAuthorize(Policy = PermissionKeys.ManagePage)]
         public JsonResult Revert(string ID, bool RetainLatest)
         {
             Service.Revert(ID, RetainLatest);


### PR DESCRIPTION
## 修复说明

为 `PageController.Revert` action 添加缺失的 `[DefaultAuthorize(Policy = PermissionKeys.ManagePage)]` 特性。

### 问题
`Revert` action 原本只有 `[HttpPost]` 属性，缺少认证和权限检查，存在安全风险。

### 解决方案
参考同控制器下的 `DeleteVersion`、`MovePage`、`Publish` 等类似操作，统一添加 `DefaultAuthorize` 权限检查。

### 变更文件
- `src/ZKEACMS/Controllers/PageController.cs`